### PR TITLE
Update build_te.bat

### DIFF
--- a/build_te.bat
+++ b/build_te.bat
@@ -162,7 +162,7 @@ if DEFINED dev (
 
 if DEFINED base_folder (
 
-	  if EXIST base_folder (
+	  if EXIST !base_folder! (
 		call :realpath !base_folder!
 		SET base_folder=!base_folder!
 		echo "[INFO] Building in a fresh base folder: " !base_folder!


### PR DESCRIPTION
Hi,
I'm running the build_te.bat script with the following options:
`build_te.bat -t C:\apache-tomcat-7.0.52 -b C:\TEAMEngine`

It gives me the following error:
`[FAIL] Base folder doesn't exist" C:\TEAMEngine`

I fixed it by changing the line if `EXIST base_folder` of the script.